### PR TITLE
fix: update angular core peer dep typo

### DIFF
--- a/projects/hyperdash-angular/package.json
+++ b/projects/hyperdash-angular/package.json
@@ -15,7 +15,7 @@
   },
   "peerDependencies": {
     "@angular/common": "^11.0.2",
-    "@angular/core": "^12.0.2",
+    "@angular/core": "^11.0.2",
     "@angular/platform-browser": "^11.0.2",
     "core-js": "^3.7.0",
     "rxjs": "^6.6.3",


### PR DESCRIPTION
## Description
Fix typo in peer dependency referencing wrong (non-existent) version of @angular/core



### Testing
N/A

### Checklist:
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
